### PR TITLE
Create new events with property signatures

### DIFF
--- a/macros/parse.sql
+++ b/macros/parse.sql
@@ -1,28 +1,24 @@
 {% macro is_date(item) %}
-{% set t = modules.datetime.datetime.now() %}
+    {% set t = modules.datetime.datetime.now() %}
     --  Find better way to figure out if its a date. but this works for now
-     {{ return(t.__class__ == item.__class__) }}
-{% endmacro %}
+    {{ return(t.__class__ == item.__class__) }}
+{% endmacro %} 
 
 
 {% macro is_property(index, columns) %}
-
-{% set column = columns[index] %}
-
-{% if "context_" | lower in column.name | lower %}
-{ return(false)}
-{ elif "event" | lower == column.name | lower %}
-{{ return(false) }} 
-{% else %}
-{{ return(true) }}
-{% endif %}
+    {% set column = columns[index] %}
+    {% if "context_" | lower in column.name | lower %}
+        { return(false)}
+    { elif "event" | lower == column.name | lower %}
+        {{ return(false) }} 
+    {% else %}
+        {{ return(true) }}
+    {% endif %}
 {% endmacro %}
 
 
 {% macro build_event_info(index, column_names, item) %}
-    
     {% set column = column_names[index] %}
-
     {% if "event" == column.name | lower %} 
         {{ return(("event_name", item)) }}
     {% elif "version" == column.name | lower %}
@@ -36,117 +32,106 @@
 
 {% macro convert_to_data_type(item) %}
 -- https://www.webforefront.com/django/usebuiltinjinjafilters.html
-
--- intialize variable as empty 
-{% set item_type = '' %}
-{% if item is none %}
-{% set item_type = "Null" %}
-{% elif item is string %}
-{% set item_type = "String" %}
-{% elif item is number %}
-{% set item_type = "Number" %}
-{% elif item is mapping %}
-{   % set item_type = "Dict" %}
-{% elif avo_audit.is_date(item) %}
-{% set item_type = "Datetime" %}
-{% endif %}
-{{ return(item_type) }}
+    {% if item is none %}
+        {{ return("Null") }}
+    {% elif item is string %}
+        {{ return("String") }}
+    {% elif item is number %}
+        {{ return("Number") }}
+    {% elif item is mapping %}
+        {{ return("Dict") }}
+    {% elif avo_audit.is_date(item) %}
+        {{ return("Datetime")}}
+    {% endif %}
+    {{ return(item_type) }}
 {% endmacro %}
 
 
 {% macro parse_relation(relation, timewindow) %}
 
-{%- set raw_columns = adapter.get_columns_in_relation(relation) -%}
+    {%- set raw_columns = adapter.get_columns_in_relation(relation) -%}
+    {% set check_cols_csv = filter_columns | map(attribute='quoted') | join(', ') %}
 
+    {%- call statement('events', fetch_result=True) -%}
+    -- TODO: Move this call statement out of the macro by converting it to runquery
+        -- https://docs.getdbt.com/reference/dbt-jinja-functions/statement-blocks
+        select * from {{ relation }} WHERE DATE(received_at) >= {{ dbt_date.n_days_ago(20, tz='UTC') }} LIMIT 1000
+    {%- endcall -%}
 
-{% set check_cols_csv = filter_columns | map(attribute='quoted') | join(', ') %}
-
-
-{%- call statement('events', fetch_result=True) -%}
--- https://docs.getdbt.com/reference/dbt-jinja-functions/statement-blocks
-
-    select * from {{ relation }} WHERE DATE(received_at) >= {{ dbt_date.n_days_ago(20, tz='UTC') }} LIMIT 1000
-
-{%- endcall -%}
-
-{%- set events = load_result('events') -%}
-{%- set events_data = events['data'] -%}
-
-{%- set event_infos = [] %}
+    {%- set events = load_result('events') -%}
+    {%- set events_data = events['data'] -%}
+    {%- set event_infos = [] %}
 
 --- convert the data into data types
-{%- set new_rows = [] %}
-{% for rower in events_data %}
-
-{%- set new_columns = [] %}
-{%- set event_info_columns = ({}) %}
-{% for item in rower %}
-{% set event_info = avo_audit.build_event_info(loop.index-1, raw_columns, item) %}
-{% if event_info != none %}
-    {% do event_info_columns.update({event_info[0]: event_info[1]}) %}
-{% else %}
-{% set item = avo_audit.convert_to_data_type(item) %}
-{% do new_columns.append(item) %}
-{% endif %}
-{% endfor %}
-{% do new_rows.append(new_columns) %}
-{% do event_infos.append(event_info_columns) %}
-{% endfor %}
+    {%- set new_rows = [] %}
+     -- O(n"2)
+    {% for rower in events_data %}
+        {%- set new_columns = [] %}
+        {%- set event_info_columns = ({}) %}
+        {% for item in rower %}
+            {% set event_info = avo_audit.build_event_info(loop.index-1, raw_columns, item) %}
+            {% if event_info != none %}
+                {% do event_info_columns.update({event_info[0]: event_info[1]}) %}
+            {% else %}
+                {% set item = avo_audit.convert_to_data_type(item) %}
+                {% do new_columns.append(item) %}
+            {% endif %}
+        {% endfor %}
+        {% do new_rows.append(new_columns) %}
+        {% do event_infos.append(event_info_columns) %}
+    {% endfor %}
 
 --- clean up the columns we know we dont want in the array
 --- event, context_
 
-{% for r in new_rows %}
-
-{% for column in r %}
-{% if not (avo_audit.is_property(loop.index-1, raw_columns)) %}
-{% do r.pop(loop.index-1) %}
-{% endif %}
-{% endfor %}
-{% endfor %}
-
-{% set property_columns = [] %}
-
-
-{% for column in raw_columns %}
-
-{% if (avo_audit.is_property(loop.index-1, raw_columns)) %}
-{% do property_columns.append(column.name) %}
-{% endif %}
-{% endfor %}
-
-{% set eventNameToVersionToSignatures = [] %}
-
-
-{% for r in new_rows %}
-
-{% set event_info = event_infos[loop.index -1] %}
-
-{% set eventNameToVersionToSignature = [] %}
-
-{% do eventNameToVersionToSignatures.append((event_info["event_name"], event_info["version"], property_columns, r)) %}
-
-{% endfor %}
-
-{{ log(eventNameToVersionToSignatures, true) }}
-
-{%- call statement('create', fetch_result=True) -%}
-
-    CREATE TABLE IF NOT EXISTS
-        dbt_avo_test.alex (event_name STRING, version STRING, property_name_mapping STRING, property_signature_mapping STRING);
-    INSERT INTO
-        dbt_avo_test.alex (event_name, version, property_name_mapping, property_signature_mapping)
-    VALUES
-        {% for valuesRow in eventNameToVersionToSignatures %}
-            ("{{valuesRow[0]}}", "{{valuesRow[1]}}", "{{valuesRow[2]}}", "{{valuesRow[3]}}")
-            {% if not loop.last %}
-            ,
+    -- O(n"2)
+    {% for r in new_rows %}
+        {% for column in r %}
+            {% if not (avo_audit.is_property(loop.index-1, raw_columns)) %}
+                {% do r.pop(loop.index-1) %}
             {% endif %}
         {% endfor %}
+    {% endfor %}
 
-{%- endcall -%}
+    {% set property_columns = [] %}
 
+     -- O(n)
+    {% for column in raw_columns %}
 
-select * from {{ relation }}
+        {% if (avo_audit.is_property(loop.index-1, raw_columns)) %}
+            {% do property_columns.append(column.name) %}
+        {% endif %}
+    {% endfor %}
 
+    {% set eventNameToVersionToSignatures = [] %}
+
+    -- O(n)
+    {% for r in new_rows %}
+
+        {% set event_info = event_infos[loop.index -1] %}
+
+        {% set eventNameToVersionToSignature = [] %}
+
+        {% do eventNameToVersionToSignatures.append((event_info["event_name"], event_info["version"], property_columns, r)) %}
+
+    {% endfor %}
+
+    {%- call statement('create', fetch_result=True) -%}
+
+        CREATE TABLE IF NOT EXISTS
+            dbt_avo_test.alex (event_name STRING, version STRING, property_name_mapping STRING, property_signature_mapping STRING);
+        INSERT INTO
+            dbt_avo_test.alex (event_name, version, property_name_mapping, property_signature_mapping)
+        VALUES
+            {% for valuesRow in eventNameToVersionToSignatures %}
+                ("{{valuesRow[0]}}", "{{valuesRow[1]}}", "{{valuesRow[2]}}", "{{valuesRow[3]}}")
+                {% if not loop.last %}
+                ,
+                {% endif %}
+            {% endfor %}
+
+    {%- endcall -%}
+
+    -- TODO: Get rid of this select
+    select * from {{ relation }}
 {% endmacro %}

--- a/models/example/my_test_model.sql
+++ b/models/example/my_test_model.sql
@@ -10,5 +10,5 @@
 
 
 {{
-    parse_relation(dbt_relation)
+    parse_relation(dbt_relation, 10)
 }}


### PR DESCRIPTION
## What changed

We managed to transform a table for a single event into it's signatures using call statements and for loops.
This loads up the warehouse data into jinja memory context - which I am still not quite sure where this memory is located (e.g bigQuery memory or my computer?) 
It then transforms the data with jinja and side-effects to inserting into a table that we create. 

This is not ideal, as we would want to use the default dbt select statement for the final result, but now we are discarding that model.

We've started experimenting with using the default select statement to do these transformations and limit the usage of in memory loops. 
However we are stuck at being able to transform the values into it's signatures on the fly. 

Creating this PR for exposure and context as we are coming into a cool-down week in Avo, so we will be taking a break from this repo next week to work on other things next week.
