### PR TITLE
allow users to set minimum event count to detect anomalies

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,7 +15,7 @@ defaults:
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 Features and bug fixes that have been applied but not released yet.
 
 
-
+# avo-audit v1.0.1
+- mininum_avg_event_volume parameter
+  Allows the user to set the mininum avarage for the algorithm to try to detect anomalies, as it can be extremely hard to detect with very low volume events.
 
 # avo-audit v1.0.0
 

--- a/integration_tests/models/experiment_test_data_normal.sql
+++ b/integration_tests/models/experiment_test_data_normal.sql
@@ -4,5 +4,5 @@
 {%- set event_source_column = 'client' -%}
 
 {{
-  avo_audit.test_detect_event_anomaly(ref('avo_audit_normal_data'), event_name_column, event_date_column, event_source_column, "2021-12-01", n_days)
+  avo_audit.test_detect_event_anomaly(ref('avo_audit_normal_data'), event_name_column, event_date_column, event_source_column, "2021-12-01", n_days, minimum_avg_event_volume=100)
 }}


### PR DESCRIPTION
## Description & motivation
Allowing users to set mininum_avg_event_volume parameter to disgard very low volume events, as the algorithm has a really hard time with low volumes, We at avo set this at 100 ourselves, as we have some events with extremely low volume

<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md